### PR TITLE
Address clippy recommendations, formatting, and idiomatic test cleanup

### DIFF
--- a/src/bin/encrypt_election.rs
+++ b/src/bin/encrypt_election.rs
@@ -2,9 +2,9 @@
 //! `generate::Election` from stdin, encrypts it, and writes a JSON-encoded `schema::Record` to
 //! stdout.
 
+use rand::thread_rng;
 use serde_json::{from_reader, to_writer_pretty};
 use std::io;
-use rand::thread_rng;
 
 use electionguard_verify::generate;
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,16 +1,16 @@
+use num::traits::{One, Pow, Zero};
 use num::BigUint;
-use num::traits::{Zero, One, Pow};
 
-use crate::crypto::group::{self, Element, Coefficient, generator};
 use crate::crypto::elgamal::Message;
-use crate::schema::*;
+use crate::crypto::group::{self, generator, Coefficient, Element};
 use crate::crypto::hash::{hash_uee, hash_umc, hash_umcc};
 use crate::errors::ErrorContext;
+use crate::schema::*;
 
 pub fn check(r: &Record) -> Result<(), Vec<String>> {
     let mut err_list = Vec::new();
     check_record(&mut ErrorContext::new(&mut err_list), r);
-    if err_list.len() == 0 {
+    if err_list.is_empty() {
         Ok(())
     } else {
         Err(err_list)
@@ -20,35 +20,53 @@ pub fn check(r: &Record) -> Result<(), Vec<String>> {
 pub fn check_record(errs: &mut ErrorContext, r: &Record) {
     // Parameters
 
-    errs.check(r.parameters.num_trustees > BigUint::zero(),
-        "num_trustees must be nonzero");
-    errs.check(r.parameters.threshold > BigUint::zero(),
-        "threshold must be nonzero");
-    errs.check(r.parameters.threshold <= r.parameters.num_trustees,
-        "threshold must not exceed num_trustees");
-    errs.check(&r.parameters.prime == group::prime(),
-        "election record uses unsupported group modulus");
-    errs.check(&r.parameters.generator == group::generator(),
-        "election record uses unsupported group generator");
+    errs.check(
+        r.parameters.num_trustees > BigUint::zero(),
+        "num_trustees must be nonzero",
+    );
+    errs.check(
+        r.parameters.threshold > BigUint::zero(),
+        "threshold must be nonzero",
+    );
+    errs.check(
+        r.parameters.threshold <= r.parameters.num_trustees,
+        "threshold must not exceed num_trustees",
+    );
+    errs.check(
+        &r.parameters.prime == group::prime(),
+        "election record uses unsupported group modulus",
+    );
+    errs.check(
+        &r.parameters.generator == group::generator(),
+        "election record uses unsupported group generator",
+    );
 
     // Trustee private keys
 
-    errs.check(BigUint::from(r.trustee_public_keys.len()) == r.parameters.num_trustees,
-        "wrong number of public trustee public keys");
+    errs.check(
+        BigUint::from(r.trustee_public_keys.len()) == r.parameters.num_trustees,
+        "wrong number of public trustee public keys",
+    );
 
     for (i, tpk) in r.trustee_public_keys.iter().enumerate() {
         let mut errs = errs.scope(&format!("trustee public key #{}", i));
-        errs.check(BigUint::from(tpk.coefficients.len()) == r.parameters.threshold,
-            "wrong number of coefficients");
+        errs.check(
+            BigUint::from(tpk.coefficients.len()) == r.parameters.threshold,
+            "wrong number of coefficients",
+        );
 
         for (j, tc) in tpk.coefficients.iter().enumerate() {
             let mut errs = errs.scope(&format!("coefficient #{}", j));
             // Note: this check uses the base hash, not the extended base hash.  The extended hash
             // isn't computed until after the trustee keys have been generated.
-            errs.check(tc.proof.check(
-                &tc.public_key,
-                |key, comm| hash_uee(&r.base_hash, key, comm),
-            ).is_ok(), "invalid Schnorr proof of key ownership");
+            errs.check(
+                tc.proof
+                    .check(&tc.public_key, |key, comm| {
+                        hash_uee(&r.base_hash, key, comm)
+                    })
+                    .is_ok(),
+                "invalid Schnorr proof of key ownership",
+            );
         }
     }
 
@@ -56,33 +74,47 @@ pub fn check_record(errs: &mut ErrorContext, r: &Record) {
 
     for (i, cb) in r.cast_ballots.iter().enumerate() {
         let mut errs = errs.scope(&format!("cast ballot #{}", i));
-        errs.check(cb.contests.len() == r.contest_tallies.len(),
-            "wrong number of contests");
+        errs.check(
+            cb.contests.len() == r.contest_tallies.len(),
+            "wrong number of contests",
+        );
 
         for (j, cc) in cb.contests.iter().enumerate() {
             let mut errs = errs.scope(&format!("contest #{}", j));
             if let Some(ct) = errs.check_get(&r.contest_tallies, j) {
-                errs.check(cc.selections.len() == ct.selections.len(),
-                    "wrong number of selections for contest");
+                errs.check(
+                    cc.selections.len() == ct.selections.len(),
+                    "wrong number of selections for contest",
+                );
             }
-            errs.check(cc.max_selections == BigUint::one(),
-                "max_selections is not 1");
+            errs.check(
+                cc.max_selections == BigUint::one(),
+                "max_selections is not 1",
+            );
 
             for (k, cs) in cc.selections.iter().enumerate() {
                 let mut errs = errs.scope(&format!("selection #{}", k));
-                errs.check(cs.proof.check_zero_one(
-                    &r.joint_public_key,
-                    &cs.message,
-                    |msg, comm0, comm1| hash_umcc(&r.extended_base_hash, msg, comm0, comm1),
-                ).is_ok(), "invalid Chaum-Pedersen disjunction proof");
+                errs.check(
+                    cs.proof
+                        .check_zero_one(&r.joint_public_key, &cs.message, |msg, comm0, comm1| {
+                            hash_umcc(&r.extended_base_hash, msg, comm0, comm1)
+                        })
+                        .is_ok(),
+                    "invalid Chaum-Pedersen disjunction proof",
+                );
             }
 
-            errs.check(cc.num_selections_proof.check_plaintext(
-                &r.joint_public_key,
-                &compute_selection_sum(&cc.selections),
-                &cc.max_selections,
-                |msg, comm| hash_umc(&r.extended_base_hash, msg, comm),
-            ).is_ok(), "invalid Chaum-Pedersen proof for selection total");
+            errs.check(
+                cc.num_selections_proof
+                    .check_plaintext(
+                        &r.joint_public_key,
+                        &compute_selection_sum(&cc.selections),
+                        &cc.max_selections,
+                        |msg, comm| hash_umc(&r.extended_base_hash, msg, comm),
+                    )
+                    .is_ok(),
+                "invalid Chaum-Pedersen proof for selection total",
+            );
         }
     }
 
@@ -92,8 +124,10 @@ pub fn check_record(errs: &mut ErrorContext, r: &Record) {
         let mut errs = errs.scope(&format!("contest tally #{}", i));
         for (j, st) in ct.selections.iter().enumerate() {
             let mut errs = errs.scope(&format!("selection tally #{}", j));
-            errs.check(st.value.encrypted_value == compute_encrypted_tally(&r.cast_ballots, i, j),
-                "encrypted sum was not computed correctly");
+            errs.check(
+                st.value.encrypted_value == compute_encrypted_tally(&r.cast_ballots, i, j),
+                "encrypted sum was not computed correctly",
+            );
             check_decrypted_value(&mut errs, r, &st.value);
         }
     }
@@ -102,14 +136,18 @@ pub fn check_record(errs: &mut ErrorContext, r: &Record) {
 
     for (i, sb) in r.spoiled_ballots.iter().enumerate() {
         let mut errs = errs.scope(&format!("spoiled ballot #{}", i));
-        errs.check(sb.contests.len() == r.contest_tallies.len(),
-            "wrong number of contests");
+        errs.check(
+            sb.contests.len() == r.contest_tallies.len(),
+            "wrong number of contests",
+        );
 
         for (j, sc) in sb.contests.iter().enumerate() {
             let mut errs = errs.scope(&format!("contest #{}", j));
             if let Some(ct) = errs.check_get(&r.contest_tallies, j) {
-                errs.check(sc.selections.len() == ct.selections.len(),
-                    "wrong number of selections for contest");
+                errs.check(
+                    sc.selections.len() == ct.selections.len(),
+                    "wrong number of selections for contest",
+                );
             }
 
             for (k, ss) in sc.selections.iter().enumerate() {
@@ -121,72 +159,98 @@ pub fn check_record(errs: &mut ErrorContext, r: &Record) {
 
     // Miscellaneous checks
 
-    errs.check(r.base_hash == compute_base_hash(&r.parameters),
-        "base hash was not computed correctly");
-    errs.check(r.joint_public_key == compute_joint_public_key(&r.trustee_public_keys),
-        "joint public key was not computed correctly");
-    errs.check(r.extended_base_hash ==
-        compute_extended_base_hash(&r.base_hash, &r.trustee_public_keys),
-        "extended base hash was not computed correctly");
+    errs.check(
+        r.base_hash == compute_base_hash(&r.parameters),
+        "base hash was not computed correctly",
+    );
+    errs.check(
+        r.joint_public_key == compute_joint_public_key(&r.trustee_public_keys),
+        "joint public key was not computed correctly",
+    );
+    errs.check(
+        r.extended_base_hash == compute_extended_base_hash(&r.base_hash, &r.trustee_public_keys),
+        "extended base hash was not computed correctly",
+    );
 }
 
-
 fn check_decrypted_value(errs: &mut ErrorContext, r: &Record, dv: &DecryptedValue) {
-    errs.check(dv.decrypted_value == generator().pow(&dv.cleartext),
-        "decrypted value does not match cleartext");
+    errs.check(
+        dv.decrypted_value == generator().pow(&dv.cleartext),
+        "decrypted value does not match cleartext",
+    );
 
-    errs.check(dv.decrypted_value ==
-        &dv.encrypted_value.ciphertext / &compute_share_product(&dv.shares),
-        "decrypted value was not computed correctly");
+    errs.check(
+        dv.decrypted_value == &dv.encrypted_value.ciphertext / &compute_share_product(&dv.shares),
+        "decrypted value was not computed correctly",
+    );
 
     for (i, s) in dv.shares.iter().enumerate() {
         if let Some(ref proof) = s.proof {
-            errs.check(s.recovery.is_none(),
-                "decrypted value has both proof and recovery fragments");
+            errs.check(
+                s.recovery.is_none(),
+                "decrypted value has both proof and recovery fragments",
+            );
 
             if let Some(tpk) = errs.check_get(&r.trustee_public_keys, i) {
                 if let Some(c) = errs.check_get(&tpk.coefficients, 0) {
-                    errs.check(proof.check_exp(
-                        &c.public_key,
-                        &dv.encrypted_value.public_key,
-                        &s.share,
-                        |msg, comm| hash_umc(&r.extended_base_hash, msg, comm),
-                    ).is_ok(), "invalid Chaum-Pedersen proof of correct share computation");
+                    errs.check(
+                        proof
+                            .check_exp(
+                                &c.public_key,
+                                &dv.encrypted_value.public_key,
+                                &s.share,
+                                |msg, comm| hash_umc(&r.extended_base_hash, msg, comm),
+                            )
+                            .is_ok(),
+                        "invalid Chaum-Pedersen proof of correct share computation",
+                    );
                 }
             }
         } else if let Some(ref sr) = s.recovery {
             for (j, f) in sr.fragments.iter().enumerate() {
                 let mut errs = errs.scope(&format!("recovery fragment #{}", j));
 
-                errs.check(f.trustee_index >= BigUint::one() &&
-                    f.trustee_index <= r.parameters.num_trustees,
-                    "trustee index is out of range");
+                errs.check(
+                    f.trustee_index >= BigUint::one()
+                        && f.trustee_index <= r.parameters.num_trustees,
+                    "trustee index is out of range",
+                );
 
-                errs.check(f.lagrange_coefficient ==
-                    compute_lagrange_coefficient(&sr.fragments, j),
-                    "Lagrange coefficient was computed incorrectly");
+                errs.check(
+                    f.lagrange_coefficient == compute_lagrange_coefficient(&sr.fragments, j),
+                    "Lagrange coefficient was computed incorrectly",
+                );
 
                 if let Some(_tpk) = errs.check_get(&r.trustee_public_keys, i) {
                     // TODO: Replace with the proper public key corresponding to Pil.
                     let K_recovery = Element::one();
                     // TODO: this check is expected to fail until the above TODO is fixed
-                    errs.check(f.proof.check_exp(
-                        &K_recovery,
-                        &dv.encrypted_value.public_key,
-                        &f.fragment,
-                        |msg, comm| hash_umc(&r.extended_base_hash, msg, comm),
-                    ).is_ok(), "invalid Chaum-Pedersen proof of correct fragment computation");
+                    errs.check(
+                        f.proof
+                            .check_exp(
+                                &K_recovery,
+                                &dv.encrypted_value.public_key,
+                                &f.fragment,
+                                |msg, comm| hash_umc(&r.extended_base_hash, msg, comm),
+                            )
+                            .is_ok(),
+                        "invalid Chaum-Pedersen proof of correct fragment computation",
+                    );
                 }
             }
 
-            errs.check(s.share == compute_reassembled_share(&sr.fragments),
-                "reassembly of share from fragments was not computed correctly");
+            errs.check(
+                s.share == compute_reassembled_share(&sr.fragments),
+                "reassembly of share from fragments was not computed correctly",
+            );
         } else {
-            errs.check(false, "decrypted value has neither proof nor recovery fragments");
+            errs.check(
+                false,
+                "decrypted value has neither proof nor recovery fragments",
+            );
         }
     }
 }
-
 
 pub fn compute_selection_sum(cast_selections: &[CastSelection]) -> Message {
     // (1, 1) is a valid encryption of zero for any key, with zero as the one-time secret.
@@ -223,15 +287,11 @@ pub fn compute_encrypted_tally(
     sum
 }
 
-pub fn compute_base_hash(
-    _parameters: &Parameters,
-) -> BigUint {
+pub fn compute_base_hash(_parameters: &Parameters) -> BigUint {
     BigUint::zero() // TODO
 }
 
-pub fn compute_joint_public_key(
-    trustee_public_keys: &[TrusteePublicKey],
-) -> Element {
+pub fn compute_joint_public_key(trustee_public_keys: &[TrusteePublicKey]) -> Element {
     let mut product = Element::one();
 
     for tpk in trustee_public_keys {
@@ -251,9 +311,7 @@ pub fn compute_extended_base_hash(
 }
 
 /// Compute the decrypted version of `message.ciphertext`, using the product of the `shares`.
-pub fn compute_share_product(
-    shares: &[Share],
-) -> Element {
+pub fn compute_share_product(shares: &[Share]) -> Element {
     let mut product = Element::one();
     for s in shares {
         product = &product * &s.share;
@@ -282,9 +340,7 @@ pub fn compute_lagrange_coefficient(
     numerator / denominator
 }
 
-pub fn compute_reassembled_share(
-    fragments: &[Fragment],
-) -> Element {
+pub fn compute_reassembled_share(fragments: &[Fragment]) -> Element {
     let mut product = Element::one();
     for f in fragments {
         product = &product * &f.fragment.pow(&f.lagrange_coefficient.to_exponent());

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,5 +1,5 @@
 pub mod chaum_pedersen;
 pub mod elgamal;
+pub mod group;
 pub mod hash;
 pub mod schnorr;
-pub mod group;

--- a/src/crypto/chaum_pedersen/disj.rs
+++ b/src/crypto/chaum_pedersen/disj.rs
@@ -39,10 +39,8 @@ impl Proof {
         ));
         let challenge_ok = combined_challenge == expected_challenge;
 
-        let (response_left_status, response_right_status) = self.transcript_zero_one(
-            public_key,
-            message,
-        );
+        let (response_left_status, response_right_status) =
+            self.transcript_zero_one(public_key, message);
 
         Status {
             challenge: challenge_ok,
@@ -57,16 +55,10 @@ impl Proof {
         message: &Message,
     ) -> (super::ResponseStatus, super::ResponseStatus) {
         (
-            self.left.transcript_plaintext(
-                public_key,
-                message,
-                &0_u8.into(),
-            ),
-            self.right.transcript_plaintext(
-                public_key,
-                message,
-                &1_u8.into(),
-            ),
+            self.left
+                .transcript_plaintext(public_key, message, &0_u8.into()),
+            self.right
+                .transcript_plaintext(public_key, message, &1_u8.into()),
         )
     }
 
@@ -164,12 +156,11 @@ impl Status {
     }
 }
 
-
 #[cfg(test)]
 mod test {
+    use super::Proof;
     use crate::crypto::elgamal::{self, Message};
     use crate::crypto::hash::hash_umcc;
-    use super::Proof;
 
     /// Encrypt the value zero, prove that it's either zero or one, and check both parts of the
     /// proof.
@@ -193,11 +184,9 @@ mod test {
             |msg, comm0, comm1| hash_umcc(&extended_base_hash, msg, comm0, comm1),
         );
 
-        let status = proof.check_zero_one(
-            &public_key,
-            &message,
-            |msg, comm0, comm1| hash_umcc(&extended_base_hash, msg, comm0, comm1),
-        );
+        let status = proof.check_zero_one(&public_key, &message, |msg, comm0, comm1| {
+            hash_umcc(&extended_base_hash, msg, comm0, comm1)
+        });
         dbg!(&status);
         assert!(status.is_ok());
     }
@@ -224,11 +213,9 @@ mod test {
             |msg, comm0, comm1| hash_umcc(&extended_base_hash, msg, comm0, comm1),
         );
 
-        let status = proof.check_zero_one(
-            &public_key,
-            &message,
-            |msg, comm0, comm1| hash_umcc(&extended_base_hash, msg, comm0, comm1),
-        );
+        let status = proof.check_zero_one(&public_key, &message, |msg, comm0, comm1| {
+            hash_umcc(&extended_base_hash, msg, comm0, comm1)
+        });
         dbg!(&status);
         assert!(status.is_ok());
     }
@@ -256,11 +243,9 @@ mod test {
             |msg, comm0, comm1| hash_umcc(&extended_base_hash, msg, comm0, comm1),
         );
 
-        let status = proof.check_zero_one(
-            &public_key,
-            &message,
-            |msg, comm0, comm1| hash_umcc(&extended_base_hash, msg, comm0, comm1),
-        );
+        let status = proof.check_zero_one(&public_key, &message, |msg, comm0, comm1| {
+            hash_umcc(&extended_base_hash, msg, comm0, comm1)
+        });
         dbg!(&status);
         assert!(status.is_ok());
     }
@@ -288,11 +273,9 @@ mod test {
             |msg, comm0, comm1| hash_umcc(&extended_base_hash, msg, comm0, comm1),
         );
 
-        let status = proof.check_zero_one(
-            &public_key,
-            &message,
-            |msg, comm0, comm1| hash_umcc(&extended_base_hash, msg, comm0, comm1),
-        );
+        let status = proof.check_zero_one(&public_key, &message, |msg, comm0, comm1| {
+            hash_umcc(&extended_base_hash, msg, comm0, comm1)
+        });
         dbg!(&status);
         assert!(status.is_ok());
     }

--- a/src/crypto/elgamal.rs
+++ b/src/crypto/elgamal.rs
@@ -1,7 +1,7 @@
-use num::BigUint;
+use crate::crypto::group::{generator, Element, Exponent};
 use num::traits::Pow;
+use num::BigUint;
 use serde::{Deserialize, Serialize};
-use crate::crypto::group::{Element, Exponent, generator};
 
 /// An ElGamal message `(c, d)` encoding zero. This is useful because
 /// you can only combine two ciphertexts if they both encode zero, as
@@ -24,11 +24,7 @@ pub struct Message {
 
 impl Message {
     /// Encrypt `m` using `public_key` and a `one_time_secret` key.
-    pub fn encrypt(
-        public_key: &Element,
-        m: &BigUint,
-        one_time_secret: &Exponent,
-    ) -> Message {
+    pub fn encrypt(public_key: &Element, m: &BigUint, one_time_secret: &Exponent) -> Message {
         let g = generator();
         let h = public_key;
         let r = one_time_secret;
@@ -75,11 +71,10 @@ impl Message {
     }
 }
 
-
 #[cfg(test)]
 pub mod test {
-    use num::BigUint;
     use super::*;
+    use num::BigUint;
 
     pub fn private_key() -> Exponent {
         BigUint::from(2546_u32).into()

--- a/src/crypto/group.rs
+++ b/src/crypto/group.rs
@@ -1,8 +1,8 @@
-use num::BigUint;
 use lazy_static::*;
-use num::traits::{Zero, One, Pow, Num};
-use std::ops::{Mul, Add, Sub, Neg, Div};
-use serde::{Serialize, Deserialize};
+use num::traits::{Num, One, Pow, Zero};
+use num::BigUint;
+use serde::{Deserialize, Serialize};
+use std::ops::{Add, Div, Mul, Neg, Sub};
 
 // TODO: custom serde instances that reject things not in the group
 
@@ -122,7 +122,6 @@ pub fn prime_minus_one() -> &'static BigUint {
     &*PRIME_MODULUS_MINUS_ONE
 }
 
-
 // Multiplicative group operations
 
 impl One for Element {
@@ -139,7 +138,9 @@ impl Element {
         // "In the special case where m is a prime, ϕ(m) = m-1, and a modular
         // inverse is given by a^-1 = a^(m-2) (mod m)."
         Element::unchecked(
-            self.element.modpow(&(&*PRIME_MODULUS - 2_u8), &*PRIME_MODULUS))
+            self.element
+                .modpow(&(&*PRIME_MODULUS - 2_u8), &*PRIME_MODULUS),
+        )
     }
 }
 
@@ -196,7 +197,6 @@ pub fn gen_pow(exp: &Exponent) -> Element {
     Element::gen().pow(exp)
 }
 
-
 // Additive exponential group operations
 
 impl Zero for Exponent {
@@ -247,8 +247,7 @@ impl Sub for Exponent {
     fn sub(self, other: Exponent) -> Exponent {
         let a = self.exponent;
         let b = other.exponent;
-        Exponent::unchecked((a + &*PRIME_MODULUS_MINUS_ONE - b)
-                            % &*PRIME_MODULUS_MINUS_ONE)
+        Exponent::unchecked((a + &*PRIME_MODULUS_MINUS_ONE - b) % &*PRIME_MODULUS_MINUS_ONE)
     }
 }
 
@@ -258,8 +257,7 @@ impl Sub for &Exponent {
     fn sub(self, other: &Exponent) -> Exponent {
         let a = &self.exponent;
         let b = &other.exponent;
-        Exponent::unchecked((a + &*PRIME_MODULUS_MINUS_ONE - b)
-                            % &*PRIME_MODULUS_MINUS_ONE)
+        Exponent::unchecked((a + &*PRIME_MODULUS_MINUS_ONE - b) % &*PRIME_MODULUS_MINUS_ONE)
     }
 }
 
@@ -315,7 +313,6 @@ impl Pow<&BigUint> for &Exponent {
     }
 }
 
-
 // Generic arithmetic mod `p`
 
 impl Zero for Coefficient {
@@ -342,7 +339,9 @@ impl Coefficient {
         // "In the special case where m is a prime, ϕ(m) = m-1, and a modular
         // inverse is given by a^-1 = a^(m-2) (mod m)."
         Coefficient::unchecked(
-            self.coefficient.modpow(&(&*PRIME_MODULUS - 2_u8), &*PRIME_MODULUS))
+            self.coefficient
+                .modpow(&(&*PRIME_MODULUS - 2_u8), &*PRIME_MODULUS),
+        )
     }
 }
 
@@ -372,8 +371,7 @@ impl Sub for Coefficient {
     fn sub(self, other: Coefficient) -> Coefficient {
         let a = self.coefficient;
         let b = other.coefficient;
-        Coefficient::unchecked((a + &*PRIME_MODULUS - b)
-                            % &*PRIME_MODULUS)
+        Coefficient::unchecked((a + &*PRIME_MODULUS - b) % &*PRIME_MODULUS)
     }
 }
 
@@ -383,8 +381,7 @@ impl Sub for &Coefficient {
     fn sub(self, other: &Coefficient) -> Coefficient {
         let a = &self.coefficient;
         let b = &other.coefficient;
-        Coefficient::unchecked((a + &*PRIME_MODULUS - b)
-                            % &*PRIME_MODULUS)
+        Coefficient::unchecked((a + &*PRIME_MODULUS - b) % &*PRIME_MODULUS)
     }
 }
 
@@ -454,7 +451,6 @@ impl Pow<&BigUint> for &Coefficient {
     }
 }
 
-
 // BigUint -> Element/Exponent conversion
 
 /// Conversion from a number into a group element (via `TryFrom`) can fail if
@@ -465,7 +461,7 @@ pub enum GroupError {
         number: BigUint,
         /// The modulus of the group
         modulus: &'static BigUint,
-    }
+    },
 }
 
 impl From<BigUint> for Element {
@@ -473,7 +469,7 @@ impl From<BigUint> for Element {
     /// prime modulus of the group.
     fn from(number: BigUint) -> Self {
         if !number.is_zero() && number < *PRIME_MODULUS {
-            Element{element: number}
+            Element { element: number }
         } else {
             panic!("argument out of range for conversion to group element")
         }
@@ -485,7 +481,7 @@ impl From<BigUint> for Exponent {
     /// prime modulus of the group *minus one*.
     fn from(number: BigUint) -> Self {
         if number < *PRIME_MODULUS_MINUS_ONE {
-            Exponent{exponent: number}
+            Exponent { exponent: number }
         } else {
             panic!("argument out of range for conversion to group exponent")
         }
@@ -495,7 +491,9 @@ impl From<BigUint> for Exponent {
 impl From<BigUint> for Coefficient {
     fn from(number: BigUint) -> Self {
         if number < *PRIME_MODULUS {
-            Coefficient{coefficient: number}
+            Coefficient {
+                coefficient: number,
+            }
         } else {
             panic!("argument out of range for conversion to coefficient")
         }
@@ -523,7 +521,6 @@ impl From<u32> for Coefficient {
         BigUint::from(number).into()
     }
 }
-
 
 // # The groups defined in [IETF RFC 3526](https://tools.ietf.org/html/rfc3526)
 
@@ -584,8 +581,10 @@ mod test {
 
     #[test]
     fn prime_modulus_minus_one_correct() {
-        assert!(&*PRIME_MODULUS - BigUint::one() == *PRIME_MODULUS_MINUS_ONE,
-                "PRIME_MODULUS - 1 != PRIME_MODULUS_MINUS_ONE");
+        assert!(
+            &*PRIME_MODULUS - BigUint::one() == *PRIME_MODULUS_MINUS_ONE,
+            "PRIME_MODULUS - 1 != PRIME_MODULUS_MINUS_ONE"
+        );
     }
 }
 
@@ -594,15 +593,14 @@ mod test {
 /// hard-coded constants)
 fn parse_biguint_hex_or_panic(hex: &str) -> BigUint {
     BigUint::from_str_radix(
-        &hex.replace(" ",  "")
-            .replace("\n", "")
-            .replace("\t", ""), 16)
-        .expect("Invalid hex input for parse_biguint_hex_or_panic")
+        &hex.replace(" ", "").replace("\n", "").replace("\t", ""),
+        16,
+    )
+    .expect("Invalid hex input for parse_biguint_hex_or_panic")
 }
 
 /// The prime modulus for the 1536-bit group
-const PRIME_HEX_1536: &str =
-    "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+const PRIME_HEX_1536: &str = "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
@@ -612,8 +610,7 @@ const PRIME_HEX_1536: &str =
      670C354E 4ABC9804 F1746C08 CA237327 FFFFFFFF FFFFFFFF";
 
 /// The prime modulus for the 2048-bit group
-const PRIME_HEX_2048: &str =
-    "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+const PRIME_HEX_2048: &str = "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
@@ -626,8 +623,7 @@ const PRIME_HEX_2048: &str =
      15728E5A 8AACAA68 FFFFFFFF FFFFFFFF";
 
 /// The prime modulus for the 3072-bit group
-const PRIME_HEX_3072: &str =
-    "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+const PRIME_HEX_3072: &str = "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
@@ -644,9 +640,8 @@ const PRIME_HEX_3072: &str =
      BBE11757 7A615D6C 770988C0 BAD946E2 08E24FA0 74E5AB31
      43DB5BFC E0FD108E 4B82D120 A93AD2CA FFFFFFFF FFFFFFFF";
 
-    /// The prime modulus for the 4096-bit group
-const PRIME_HEX_4096: &str =
-    "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+/// The prime modulus for the 4096-bit group
+const PRIME_HEX_4096: &str = "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
@@ -670,8 +665,7 @@ const PRIME_HEX_4096: &str =
      FFFFFFFF FFFFFFFF";
 
 /// The prime modulus for the 6144-bit group
-const PRIME_HEX_6144: &str =
-    "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1 29024E08
+const PRIME_HEX_6144: &str = "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1 29024E08
      8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD EF9519B3 CD3A431B
      302B0A6D F25F1437 4FE1356D 6D51C245 E485B576 625E7EC6 F44C42E9
      A637ED6B 0BFF5CB6 F406B7ED EE386BFB 5A899FA5 AE9F2411 7C4B1FE6
@@ -701,8 +695,7 @@ const PRIME_HEX_6144: &str =
      6DCC4024 FFFFFFFF FFFFFFFF";
 
 /// The prime modulus for the 8192-bit group
-const PRIME_HEX_8192: &str =
-    "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+const PRIME_HEX_8192: &str = "FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -1,8 +1,8 @@
+use crate::crypto::elgamal;
+use crate::crypto::group::Element;
 use digest::Digest;
 use num::BigUint;
 use sha2::Sha256;
-use crate::crypto::elgamal;
-use crate::crypto::group::Element;
 
 /// Specifies how the challenge should be computed by specifying which
 /// inputs should be hashed, and in what order.
@@ -53,11 +53,7 @@ pub fn hash_uints(xs: &[&BigUint]) -> BigUint {
 }
 
 /// Hash together a BigUint, a message, and a commitment.
-pub fn hash_umc(
-    u: &BigUint,
-    m: &elgamal::Message,
-    c: &elgamal::Message,
-) -> BigUint {
+pub fn hash_umc(u: &BigUint, m: &elgamal::Message, c: &elgamal::Message) -> BigUint {
     hash_uints(&[
         u,
         m.public_key.as_uint(),
@@ -86,20 +82,11 @@ pub fn hash_umcc(
 }
 
 /// Hash together three BigUints.
-pub fn hash_uuu(
-    u1: &BigUint,
-    u2: &BigUint,
-    u3: &BigUint,
-) -> BigUint {
+pub fn hash_uuu(u1: &BigUint, u2: &BigUint, u3: &BigUint) -> BigUint {
     hash_uints(&[u1, u2, u3])
 }
 
 /// Hash together a BigUint and two group Elements.
-pub fn hash_uee(
-    u: &BigUint,
-    e1: &Element,
-    e2: &Element,
-) -> BigUint {
+pub fn hash_uee(u: &BigUint, e1: &Element, e2: &Element) -> BigUint {
     hash_uints(&[u, e1.as_uint(), e2.as_uint()])
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,12 @@
 // `M_{i,l}`.  These names don't fit Rust's normal style guidelines.
 #![allow(non_snake_case)]
 
-pub mod crypto;
 pub mod check;
+pub mod crypto;
+pub mod errors;
+pub mod generate;
 pub mod schema;
 pub mod serialize;
-pub mod generate;
-pub mod errors;
 
-#[cfg(test)] mod test_gen_check;
+#[cfg(test)]
+mod test_gen_check;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::crypto::chaum_pedersen;
 use crate::crypto::elgamal;
+use crate::crypto::group::{Coefficient, Element};
 use crate::crypto::schnorr;
-use crate::crypto::group::{Element, Coefficient};
 
 /// All the parameters necessary to form the election.
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -68,7 +68,6 @@ pub struct Record {
     pub spoiled_ballots: Vec<SpoiledBallot>,
 }
 
-
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TrusteePublicKey {
@@ -86,7 +85,6 @@ pub struct TrusteeCoefficient {
     /// A proof of posession of the private key.
     pub proof: schnorr::Proof,
 }
-
 
 /// An encrypted ballot, consisting of the encrypted selections for
 /// each contest, their proofs of well-formedness, and information
@@ -138,7 +136,6 @@ pub struct CastSelection {
     pub proof: chaum_pedersen::disj::Proof,
 }
 
-
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ContestTally {
@@ -152,7 +149,6 @@ pub struct SelectionTally {
     #[serde(serialize_with = "crate::serialize::decrypted_tally::serialize")]
     pub value: DecryptedValue,
 }
-
 
 /// A decryption of an encrypted ballot that was spoiled.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -173,7 +169,6 @@ pub struct SpoiledSelection {
     #[serde(serialize_with = "crate::serialize::decrypted_selection::serialize")]
     pub value: DecryptedValue,
 }
-
 
 /// The decryption of an encrypted value, with proofs that it was decrypted properly.
 // This struct has custom serialization, since its fields are serialized with different names in

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,4 +1,4 @@
-pub mod hash;
 pub mod big_uint;
-pub mod decrypted_tally;
 pub mod decrypted_selection;
+pub mod decrypted_tally;
+pub mod hash;

--- a/src/serialize/big_uint.rs
+++ b/src/serialize/big_uint.rs
@@ -1,14 +1,9 @@
 use num::{BigUint, Num};
-use serde::{Serialize, Serializer, de, Deserialize, Deserializer};
-
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Serialize)]
 #[serde(transparent)]
-pub struct SerializeBigUint<'a>(
-    #[serde(serialize_with = "self::serialize")]
-    pub &'a BigUint
-);
-
+pub struct SerializeBigUint<'a>(#[serde(serialize_with = "self::serialize")] pub &'a BigUint);
 
 pub fn serialize<S>(value: &BigUint, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/src/serialize/decrypted_selection.rs
+++ b/src/serialize/decrypted_selection.rs
@@ -1,17 +1,14 @@
-use serde::Serializer;
-use serde::ser::SerializeStruct;
 use crate::schema::DecryptedValue;
 use crate::serialize::big_uint::SerializeBigUint;
+use serde::ser::SerializeStruct;
+use serde::Serializer;
 
 pub fn serialize<S>(value: &DecryptedValue, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     let mut state = serializer.serialize_struct("DecryptedValue", 4)?;
-    state.serialize_field(
-        "cleartext",
-        &SerializeBigUint(&value.cleartext),
-    )?;
+    state.serialize_field("cleartext", &SerializeBigUint(&value.cleartext))?;
     state.serialize_field("decrypted_message", &value.decrypted_value)?;
     state.serialize_field("encrypted_message", &value.encrypted_value)?;
     state.serialize_field("shares", &value.shares)?;

--- a/src/serialize/decrypted_tally.rs
+++ b/src/serialize/decrypted_tally.rs
@@ -1,17 +1,14 @@
-use serde::Serializer;
-use serde::ser::SerializeStruct;
 use crate::schema::DecryptedValue;
 use crate::serialize::big_uint::SerializeBigUint;
+use serde::ser::SerializeStruct;
+use serde::Serializer;
 
 pub fn serialize<S>(value: &DecryptedValue, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     let mut state = serializer.serialize_struct("DecryptedValue", 4)?;
-    state.serialize_field(
-        "cleartext",
-        &SerializeBigUint(&value.cleartext),
-    )?;
+    state.serialize_field("cleartext", &SerializeBigUint(&value.cleartext))?;
     state.serialize_field("decrypted_tally", &value.decrypted_value)?;
     state.serialize_field("encrypted_tally", &value.encrypted_value)?;
     state.serialize_field("shares", &value.shares)?;

--- a/src/serialize/hash.rs
+++ b/src/serialize/hash.rs
@@ -1,5 +1,5 @@
 use num::{BigUint, Num};
-use serde::{Serialize, Serializer, de, Deserialize, Deserializer};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 pub fn serialize<S>(value: &BigUint, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -15,5 +15,3 @@ where
     let s: String = Deserialize::deserialize(deserializer)?;
     BigUint::from_str_radix(&s, 16).map_err(de::Error::custom)
 }
-
-

--- a/src/test_gen_check.rs
+++ b/src/test_gen_check.rs
@@ -1,9 +1,9 @@
+use crate::check;
+use crate::crypto::group::{generator, prime};
+use crate::generate::{self, Ballot, Contest, Election};
+use crate::schema::{BallotInfo, Parameters};
 use num::BigUint;
 use rand;
-use crate::generate::{self, Election, Ballot, Contest};
-use crate::check;
-use crate::schema::{Parameters, BallotInfo};
-use crate::crypto::group::{generator, prime};
 
 #[test]
 fn test_normal() {
@@ -27,43 +27,59 @@ fn test_normal() {
             Ballot {
                 information: dummy_information.clone(),
                 contests: vec![
-                    Contest { selections: vec![true, false, false] },
-                    Contest { selections: vec![false, true, false] },
-                    Contest { selections: vec![false, false, true] },
+                    Contest {
+                        selections: vec![true, false, false],
+                    },
+                    Contest {
+                        selections: vec![false, true, false],
+                    },
+                    Contest {
+                        selections: vec![false, false, true],
+                    },
                 ],
             },
             Ballot {
                 information: dummy_information.clone(),
                 contests: vec![
-                    Contest { selections: vec![false, true, false] },
-                    Contest { selections: vec![false, false, true] },
-                    Contest { selections: vec![false, false, true] },
+                    Contest {
+                        selections: vec![false, true, false],
+                    },
+                    Contest {
+                        selections: vec![false, false, true],
+                    },
+                    Contest {
+                        selections: vec![false, false, true],
+                    },
                 ],
             },
         ],
-        spoiled_ballots: vec![
-            Ballot {
-                information: dummy_information.clone(),
-                contests: vec![
-                    Contest { selections: vec![false, false, true] },
-                    Contest { selections: vec![false, true, false] },
-                    Contest { selections: vec![true, false, false] },
-                ],
-            },
-        ],
+        spoiled_ballots: vec![Ballot {
+            information: dummy_information.clone(),
+            contests: vec![
+                Contest {
+                    selections: vec![false, false, true],
+                },
+                Contest {
+                    selections: vec![false, true, false],
+                },
+                Contest {
+                    selections: vec![true, false, false],
+                },
+            ],
+        }],
         trustees_present: vec![true, true, true, true, true],
     };
 
     let record = generate::generate(&mut rand::thread_rng(), e);
 
     match check::check(&record) {
-        Ok(()) => {},
+        Ok(()) => {}
         Err(errs) => {
             for err in &errs {
                 eprintln!("{}", err);
             }
             panic!("check failed with {} errors", errs.len());
-        },
+        }
     }
 }
 
@@ -93,42 +109,58 @@ fn test_missing() {
             Ballot {
                 information: dummy_information.clone(),
                 contests: vec![
-                    Contest { selections: vec![true, false, false] },
-                    Contest { selections: vec![false, true, false] },
-                    Contest { selections: vec![false, false, true] },
+                    Contest {
+                        selections: vec![true, false, false],
+                    },
+                    Contest {
+                        selections: vec![false, true, false],
+                    },
+                    Contest {
+                        selections: vec![false, false, true],
+                    },
                 ],
             },
             Ballot {
                 information: dummy_information.clone(),
                 contests: vec![
-                    Contest { selections: vec![false, true, false] },
-                    Contest { selections: vec![false, false, true] },
-                    Contest { selections: vec![false, false, true] },
+                    Contest {
+                        selections: vec![false, true, false],
+                    },
+                    Contest {
+                        selections: vec![false, false, true],
+                    },
+                    Contest {
+                        selections: vec![false, false, true],
+                    },
                 ],
             },
         ],
-        spoiled_ballots: vec![
-            Ballot {
-                information: dummy_information.clone(),
-                contests: vec![
-                    Contest { selections: vec![false, false, true] },
-                    Contest { selections: vec![false, true, false] },
-                    Contest { selections: vec![true, false, false] },
-                ],
-            },
-        ],
+        spoiled_ballots: vec![Ballot {
+            information: dummy_information.clone(),
+            contests: vec![
+                Contest {
+                    selections: vec![false, false, true],
+                },
+                Contest {
+                    selections: vec![false, true, false],
+                },
+                Contest {
+                    selections: vec![true, false, false],
+                },
+            ],
+        }],
         trustees_present: vec![true, true, false, true, true],
     };
 
     let record = generate::generate(&mut rand::thread_rng(), e);
 
     match check::check(&record) {
-        Ok(()) => {},
+        Ok(()) => {}
         Err(errs) => {
             for err in &errs {
                 eprintln!("{}", err);
             }
             panic!("check failed with {} errors", errs.len());
-        },
+        }
     }
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,12 +1,25 @@
 use serde_json::from_reader;
-use std::io::Cursor;
-use std::io::Read;
+use std::{
+    error::Error,
+    fs,
+    io::{Cursor, Read},
+};
 
 use electionguard_verify::schema;
 
 #[test]
-fn test_parsing() {
-    let input = include_str!("generated.json");
-    let mut reader = Cursor::new(input);
-    from_reader::<_, schema::Record>(reader.by_ref()).expect("JSON should parse");
+fn test_parsing() -> Result<(), Box<dyn Error>> {
+    for file in fs::read_dir("tests/")? {
+        let file = file?;
+        if let Some(ext) = file.path().extension() {
+            if ext == "json" {
+                let input = fs::read_to_string(file.path())?;
+                let mut reader = Cursor::new(input);
+                from_reader::<_, schema::Record>(reader.by_ref())
+                    .expect(&format!("{:#?} should parse", file.file_name()));
+            }
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Using Rust 1.38.0, addressed some clippy recommendations, ran `cargo fmt`, and made the `test_parsing` test slightly more idiomatic.

Signed-off-by: Andrew Weiss <anweiss@github.com>